### PR TITLE
Use an empty String as a temporary param in nativeInit

### DIFF
--- a/SDLforAndroidAS/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/SDLforAndroidAS/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -1025,7 +1025,7 @@ class SDLMain implements Runnable {
     @Override
     public void run() {
         // Runs SDL_main()
-        SDLActivity.nativeInit(SDLActivity.mSingleton.getArguments());
+        SDLActivity.nativeInit("");
 
         //Log.v("SDL", "SDL thread terminated");
     }


### PR DESCRIPTION
JNI won't accept String[] as the argument. Use an empty String as a temporary measure for it to run.